### PR TITLE
Adding addon that generates HTTPS configuration and google OAuth protection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ setup-workspace:
 	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 	go get github.com/brancz/gojsontoyaml
 	jb init
-	jb install github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus@e00cb56537dd268c5d02920c3668b8f02ec73dbe
+	jb install github.com/prometheus-operator/kube-prometheus/jsonnet/kube-prometheus@main
 
 build:
 	./hack/build.sh main.jsonnet

--- a/addons/cluster-monitoring.libsonnet
+++ b/addons/cluster-monitoring.libsonnet
@@ -1,0 +1,6 @@
+// The cluster-monitoring addon provides json snippets that are specific for installations responsible for full cluster monitoring.
+
+{
+
+} +
+(import './grafana-on-gcp-oauth.libsonnet')

--- a/addons/grafana-on-gcp-oauth.libsonnet
+++ b/addons/grafana-on-gcp-oauth.libsonnet
@@ -1,0 +1,106 @@
+{
+  grafana+: {
+    // Certmanager must be installed in the cluster already!
+    certificate: {
+      apiVersion: 'cert-manager.io/v1alpha2',
+      kind: 'Certificate',
+      metadata: {
+        name: 'grafana',
+        namespace: std.extVar('namespace'),
+      },
+      spec: {
+        dnsNames: [
+          std.extVar('dns_name'),
+        ],
+        issuerRef: {
+          kind: 'ClusterIssuer',
+          name: 'letsencrypt-issuer',
+        },
+        secretName: 'grafana-certificate',
+      },
+    },
+
+    ingressService: $.grafana.service {
+      metadata+: {
+        name: 'grafana-loadbalancer',
+        annotations+: {
+          'cloud.google.com/backend-config': '{"ports": {"3000":"' + $.grafana.backendOAuth.metadata.name + '"}}',  // same name as backend-config
+        },
+      },
+      spec+: {
+        type: 'NodePort',
+        ports: std.map(
+          function(p) p {
+            nodePort: std.parseInt(std.extVar('grafana_ingress_node_port')),
+          }
+          , super.ports
+        ),
+      },
+    },
+
+    ingress: {
+      apiVersion: 'extensions/v1beta1',
+      kind: 'Ingress',
+      metadata: {
+        annotations: {
+          'kubernetes.io/ingress.global-static-ip-name': std.extVar('gcp_external_ip_address'),
+          'kubernetes.io/ingress.class': 'gce',
+          'cert-manager.io/cluster-issuer': $.grafana.certificate.spec.issuerRef.name,
+        },
+        labels: $.grafana.service.metadata.labels,
+        name: 'grafana',
+        namespace: std.extVar('namespace'),
+      },
+      rules: [{
+        host: std.extVar('dns_name'),  // gcp's external ip address
+        http: {
+          paths: [{
+            backend: {
+              serviceName: $.grafana.ingressService.metadata.name,  // same name put on service resource
+              servicePort: 3000,
+            },
+            path: '/*',
+          }],
+        },
+
+      }],
+      tls: [{
+        hosts: [
+          std.extVar('dns_name'),
+        ],
+        secretName: $.grafana.certificate.spec.secretName,
+      }],
+    },
+
+    backendOAuthSecret: {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      metadata: {
+        name: 'grafana-oauth',
+        namespace: std.extVar('namespace'),
+        labels: $.grafana.service.metadata.labels,
+      },
+      data: {
+        client_id: std.base64(std.extVar('IAP_client_id')),  // Get from IAP console as variable, needs to be encoded with base64
+        client_secret: std.base64(std.extVar('IAP_client_secret')),  // Get from IAP console as variable, needs to be encoded with base64
+      },
+    },
+
+    backendOAuth: {
+      apiVersion: 'cloud.google.com/v1',
+      kind: 'BackendConfig',
+      metadata: {
+        name: 'grafana',
+        namespace: std.extVar('namespace'),
+      },
+      spec: {
+        iap: {
+          enabled: true,
+          oauthclientCredentials: {
+            secretName: $.grafana.backendOAuthSecret.metadata.name,
+          },
+        },
+      },
+    },
+  },
+}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -27,6 +27,11 @@ jsonnet -J vendor -m manifests \
 --ext-str remote_write_url=${REMOTE_WRITE_URL:-''} \
 --ext-str slack_webhook_url=${SLACK_WEBHOOK_URL:-""} \
 --ext-str slack_channel=${SLACK_CHANNEL:-""} \
+--ext-str grafana_ingress_node_port=${GRAFANA_INGRESS_NODE_PORT} \
+--ext-str dns_name=${DNS_NAME} \
+--ext-str gcp_external_ip_address=${GCP_EXTERNAL_IP_ADDRESS} \
+--ext-str IAP_client_id=${IAP_CLIENT_ID} \
+--ext-str IAP_client_secret=${IAP_CLIENT_SECRET} \
 --ext-code is_preview_env=${IS_PREVIEW_ENV:-false} \
 "${1}" | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml' -- {}
 

--- a/main.jsonnet
+++ b/main.jsonnet
@@ -11,7 +11,7 @@ local externalVars = {
 local kp =
   (import 'kube-prometheus/main.libsonnet') +
   (import 'kube-prometheus/platforms/gke.libsonnet') +
-  (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
+  //   (import 'kube-prometheus/addons/podsecuritypolicies.libsonnet') +
   {
     values+:: {
       common+: {
@@ -45,11 +45,11 @@ local kp =
 local manifests = kp +
                   (if externalVars.remoteWriteUrl != '' then (import './addons/remote-write.libsonnet') else {}) +
                   (if externalVars.slackWebhookUrl != '' then (import './addons/slack-alerting.libsonnet') else {}) +
-                  (if externalVars.isPreviewEnv then (import './addons/preview-env.libsonnet') else {})
+                  (if externalVars.isPreviewEnv then (import './addons/preview-env.libsonnet') else (import './addons/cluster-monitoring.libsonnet'))
 ;
 
 { namespace: manifests.kubePrometheus.namespace } +
-{ 'podsecuritypolicy-restricted': manifests.restrictedPodSecurityPolicy } +
+// { 'podsecuritypolicy-restricted': manifests.restrictedPodSecurityPolicy } +
 { ['grafana/' + name]: manifests.grafana[name] for name in std.objectFields(manifests.grafana) } +
 { ['prometheus/' + name]: manifests.prometheus[name] for name in std.objectFields(manifests.prometheus) } +
 // Generic alerting rules, not related to a specific exporter.


### PR DESCRIPTION
This PR solves #7 partially, as it only adds OAuth for grafana and some work needs to be done manually as a preparation.

A follow up PR with documentation about the manual work is needed