### PR TITLE
Enable gitpod prebuilds

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,16 @@
 image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:aledbf-dev-image.0
 tasks: 
   - init: make --always-make
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true
+    addComment: true
+    addBadge: true
+    addLabel: true
 vscode:
   extensions:
     - heptio.jsonnet@0.1.0:woEDU5N62LRdgdz0g/I6sQ==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,7 +12,7 @@ github:
     addCheck: true
     addComment: true
     addBadge: true
-    addLabel: true
+    addLabel: gitpod-prebuild-done
 vscode:
   extensions:
     - heptio.jsonnet@0.1.0:woEDU5N62LRdgdz0g/I6sQ==


### PR DESCRIPTION
Since refactoring CI, we install a lot of binaries to the workspace. It would be nice if it is done before opening the workspace