### PR TITLE
Update messagebus service with new chart configs

### DIFF
--- a/components/gitpod/gitpod.libsonnet
+++ b/components/gitpod/gitpod.libsonnet
@@ -386,11 +386,11 @@ function(params) {
     },
     spec: {
       selector: {
-        component: 'messagebus',
+        'app.kubernetes.io/name': 'rabbitmq',
       },
       ports: [{
         name: 'metrics',
-        port: 15692,
+        port: 9419,
       }],
     },
   },


### PR DESCRIPTION
Changing charts on https://github.com/gitpod-io/gitpod/pull/3563 also changed labels used by its pods.
This PR aligns Prometheus service-discovery with those changes.

Fixes #47 