### PR TITLE
Change runbook URLs to runbooks hosted in this repository

### DIFF
--- a/addons/gitpod-runbooks.libsonnet
+++ b/addons/gitpod-runbooks.libsonnet
@@ -1,48 +1,46 @@
-local commonRunbookURLPatern = 'https://www.notion.so/gitpod/%s';
+local k8sUtils = (import 'github.com/kubernetes-monitoring/kubernetes-mixin/lib/utils.libsonnet');
+
+local addRunbookURL(rule) = rule {
+  [if 'alert' in rule then 'annotations']+: {
+    runbook_url: 'https://www.github.com/gitpod-io/runbooks/%s' % rule.alert + '.md',
+  },
+};
 
 {
-  values+:: {
-    prometheus+: {
-      mixin+: {
-        _config+: {
-          runbookURLPattern: commonRunbookURLPatern,
-        },
-      },
+  prometheus+: {
+    prometheusRule+: {
+      spec+:
+        k8sUtils.mapRuleGroups(addRunbookURL),
     },
-    alertmanager+: {
-      mixin+: {
-        _config+: {
-          runbookURLPattern: commonRunbookURLPatern,
-        },
-      },
+  },
+  alertmanager+: {
+    prometheusRule+: {
+      spec+:
+        k8sUtils.mapRuleGroups(addRunbookURL),
     },
-    kubeStateMetrics+: {
-      mixin+: {
-        _config+: {
-          runbookURLPattern: commonRunbookURLPatern,
-        },
-      },
+  },
+  kubeStateMetrics+: {
+    prometheusRule+: {
+      spec+:
+        k8sUtils.mapRuleGroups(addRunbookURL),
     },
-    kubernetesControlPlane+: {
-      mixin+: {
-        _config+: {
-          runbookURLPattern: commonRunbookURLPatern,
-        },
-      },
+  },
+  kubernetesControlPlane+: {
+    prometheusRule+: {
+      spec+:
+        k8sUtils.mapRuleGroups(addRunbookURL),
     },
-    nodeExporter+: {
-      mixin+: {
-        _config+: {
-          runbookURLPattern: commonRunbookURLPatern,
-        },
-      },
+  },
+  nodeExporter+: {
+    prometheusRule+: {
+      spec+:
+        k8sUtils.mapRuleGroups(addRunbookURL),
     },
-    prometheusOperator+: {
-      mixin+: {
-        _config+: {
-          runbookURLPattern: commonRunbookURLPatern,
-        },
-      },
+  },
+  prometheusOperator+: {
+    prometheusRule+: {
+      spec+:
+        k8sUtils.mapRuleGroups(addRunbookURL),
     },
   },
 }

--- a/components/gitpod/mixin/prometheus_rules.yaml
+++ b/components/gitpod/mixin/prometheus_rules.yaml
@@ -4,7 +4,7 @@
   - "alert": "GitpodLoginErrorBudgetBurn"
     "annotations":
       "description": "Error budget is being burn too quickly. At this rate, the whole monthly budget will be burnt in less than 2 days."
-      "runbook_url": "https://www.notion.so/gitpod/GitpodLoginErrorBudgetBurn"
+      "runbook_url": "https://www.github.com/gitpod-io/runbooks/GitpodLoginErrorBudgetBurn.md"
       "summary": "Error budget is being burn too quickly."
     "expr": |
       (
@@ -23,7 +23,7 @@
   - "alert": "GitpodLoginErrorBudgetBurn"
     "annotations":
       "description": "Error budget is being burn quickly. At this rate, the whole monthly budget will be burnt in less than 10 days."
-      "runbook_url": "https://www.notion.so/gitpod/GitpodLoginErrorBudgetBurn"
+      "runbook_url": "https://www.github.com/gitpod-io/runbooks/GitpodLoginErrorBudgetBurn.md"
       "summary": "Error budget is being burn quickly."
     "expr": |
       (
@@ -44,7 +44,7 @@
   - "alert": "GitpodAgentSmithPolicySaturationBudgetBurn"
     "annotations":
       "description": "Error budget is being burn too quickly. At this rate, the whole monthly budget will be burnt in less than 2 days."
-      "runbook_url": "https://www.notion.so/gitpod/GitpodAgentSmithPolicySaturationBudgetBurn"
+      "runbook_url": "https://www.github.com/gitpod-io/runbooks/GitpodAgentSmithPolicySaturationBudgetBurn.md"
       "summary": "Error budget is being burn too quickly."
     "expr": |
       (
@@ -63,7 +63,7 @@
   - "alert": "GitpodAgentSmithPolicySaturationBudgetBurn"
     "annotations":
       "description": "Error budget is being burn quickly. At this rate, the whole monthly budget will be burnt in less than 10 days."
-      "runbook_url": "https://www.notion.so/gitpod/GitpodAgentSmithPolicySaturationBudgetBurn"
+      "runbook_url": "https://www.github.com/gitpod-io/runbooks/GitpodAgentSmithPolicySaturationBudgetBurn.md"
       "summary": "Error budget is being burn quickly."
     "expr": |
       (

--- a/components/gitpod/mixin/rules/SLO/login/alerts.libsonnet
+++ b/components/gitpod/mixin/rules/SLO/login/alerts.libsonnet
@@ -12,7 +12,7 @@
               severity: 'critical',
             },
             annotations: {
-              runbook_url: 'https://www.notion.so/gitpod/GitpodLoginErrorBudgetBurn',
+              runbook_url: 'https://www.github.com/gitpod-io/runbooks/GitpodLoginErrorBudgetBurn.md',
               summary: 'Error budget is being burn too quickly.',
               description: 'Error budget is being burn too quickly. At this rate, the whole monthly budget will be burnt in less than 2 days.',
             },
@@ -36,7 +36,7 @@
               severity: 'warning',
             },
             annotations: {
-              runbook_url: 'https://www.notion.so/gitpod/GitpodLoginErrorBudgetBurn',
+              runbook_url: 'https://www.github.com/gitpod-io/runbooks/GitpodLoginErrorBudgetBurn.md',
               summary: 'Error budget is being burn quickly.',
               description: 'Error budget is being burn quickly. At this rate, the whole monthly budget will be burnt in less than 10 days.',
             },

--- a/components/gitpod/mixin/rules/SLO/policy/alerts.libsonnet
+++ b/components/gitpod/mixin/rules/SLO/policy/alerts.libsonnet
@@ -12,7 +12,7 @@
               severity: 'critical',
             },
             annotations: {
-              runbook_url: 'https://www.notion.so/gitpod/GitpodAgentSmithPolicySaturationBudgetBurn',
+              runbook_url: 'https://www.github.com/gitpod-io/runbooks/GitpodAgentSmithPolicySaturationBudgetBurn.md',
               summary: 'Error budget is being burn too quickly.',
               description: 'Error budget is being burn too quickly. At this rate, the whole monthly budget will be burnt in less than 2 days.',
             },
@@ -36,7 +36,7 @@
               severity: 'warning',
             },
             annotations: {
-              runbook_url: 'https://www.notion.so/gitpod/GitpodAgentSmithPolicySaturationBudgetBurn',
+              runbook_url: 'https://www.github.com/gitpod-io/runbooks/GitpodAgentSmithPolicySaturationBudgetBurn.md',
               summary: 'Error budget is being burn quickly.',
               description: 'Error budget is being burn quickly. At this rate, the whole monthly budget will be burnt in less than 10 days.',
             },

--- a/runbooks/AggregatedAPIDown.md
+++ b/runbooks/AggregatedAPIDown.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AggregatedAPIErrors.md
+++ b/runbooks/AggregatedAPIErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AlertmanagerClusterCrashlooping.md
+++ b/runbooks/AlertmanagerClusterCrashlooping.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AlertmanagerClusterDown.md
+++ b/runbooks/AlertmanagerClusterDown.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AlertmanagerClusterFailedToSendAlerts.md
+++ b/runbooks/AlertmanagerClusterFailedToSendAlerts.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AlertmanagerConfigInconsistent.md
+++ b/runbooks/AlertmanagerConfigInconsistent.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AlertmanagerFailedReload.md
+++ b/runbooks/AlertmanagerFailedReload.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AlertmanagerFailedToSendAlerts.md
+++ b/runbooks/AlertmanagerFailedToSendAlerts.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/AlertmanagerMembersInconsistent.md
+++ b/runbooks/AlertmanagerMembersInconsistent.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/CPUThrottlingHigh.md
+++ b/runbooks/CPUThrottlingHigh.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/GitpodAgentSmithPolicySaturationBudgetBurn.md
+++ b/runbooks/GitpodAgentSmithPolicySaturationBudgetBurn.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. 
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/GitpodLoginErrorBudgetBurn.md
+++ b/runbooks/GitpodLoginErrorBudgetBurn.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. 
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeAPIDown.md
+++ b/runbooks/KubeAPIDown.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeAPIErrorBudgetBurn.md
+++ b/runbooks/KubeAPIErrorBudgetBurn.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeAPITerminatedRequests.md
+++ b/runbooks/KubeAPITerminatedRequests.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeCPUOvercommit.md
+++ b/runbooks/KubeCPUOvercommit.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeCPUQuotaOvercommit.md
+++ b/runbooks/KubeCPUQuotaOvercommit.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeClientCertificateExpiration.md
+++ b/runbooks/KubeClientCertificateExpiration.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeClientErrors.md
+++ b/runbooks/KubeClientErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeContainerWaiting.md
+++ b/runbooks/KubeContainerWaiting.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeDaemonSetMisScheduled.md
+++ b/runbooks/KubeDaemonSetMisScheduled.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeDaemonSetNotScheduled.md
+++ b/runbooks/KubeDaemonSetNotScheduled.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeDaemonSetRolloutStuck.md
+++ b/runbooks/KubeDaemonSetRolloutStuck.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeDeploymentGenerationMismatch.md
+++ b/runbooks/KubeDeploymentGenerationMismatch.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeDeploymentReplicasMismatch.md
+++ b/runbooks/KubeDeploymentReplicasMismatch.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeHpaMaxedOut.md
+++ b/runbooks/KubeHpaMaxedOut.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeHpaReplicasMismatch.md
+++ b/runbooks/KubeHpaReplicasMismatch.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeJobCompletion.md
+++ b/runbooks/KubeJobCompletion.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeJobFailed.md
+++ b/runbooks/KubeJobFailed.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeMemoryOvercommit.md
+++ b/runbooks/KubeMemoryOvercommit.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeMemoryQuotaOvercommit.md
+++ b/runbooks/KubeMemoryQuotaOvercommit.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeNodeNotReady.md
+++ b/runbooks/KubeNodeNotReady.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeNodeReadinessFlapping.md
+++ b/runbooks/KubeNodeReadinessFlapping.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeNodeUnreachable.md
+++ b/runbooks/KubeNodeUnreachable.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubePersistentVolumeErrors.md
+++ b/runbooks/KubePersistentVolumeErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubePersistentVolumeFillingUp.md
+++ b/runbooks/KubePersistentVolumeFillingUp.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubePodCrashLooping.md
+++ b/runbooks/KubePodCrashLooping.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubePodNotReady.md
+++ b/runbooks/KubePodNotReady.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeQuotaAlmostFull.md
+++ b/runbooks/KubeQuotaAlmostFull.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeQuotaExceeded.md
+++ b/runbooks/KubeQuotaExceeded.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeQuotaFullyUsed.md
+++ b/runbooks/KubeQuotaFullyUsed.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeStateMetricsListErrors.md
+++ b/runbooks/KubeStateMetricsListErrors.md
@@ -1,5 +1,85 @@
-Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+# KubeStateMetricsListErrors
+
+## Meaning
+
+The component [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) which is responsible to read the state of a kubernetes cluster and expose metrics related to such state is failing to get responses from kube-apiserver at an elevated rate.
+
+## Impact
+
+Kube-state-metrics is not able to expose metrics about kubernetes state, maybe only about some specific resources or entirely. While it doesn't mean direct impact to our users, it can affect our monitoring system.
+
+If kube-state-metrics isn't able to query the state of resources such as `Deployments` and `Pods`, then we won't be able to receive alerts about pods that may be stuck on `CrashLoopBackoff`. This is considered a `critical` alert because our monitoring solution is vital for keeping Gitpod reliable.
+
+## Diagnosis
+
+We've noticed that kube-prometheus, which serves the foundation for our monitoring stack, deploys by default a version of kube-state-metrics, [v2.0.0-rc1](https://github.com/prometheus-operator/kube-prometheus/blob/f5f72e1b5011830da821a7f6afff667c27b6fc37/jsonnet/kube-prometheus/versions.json#L5), which is [incompatible with our kubernetes cluster version](https://github.com/kubernetes/kube-state-metrics#compatibility-matrix) (we use 1.17 today). Transforming this super important alert into a super noisy one, thus not really useful.
+
+## Mitigation
+
+The [agreed mitigation is to momentarily silence the alert](https://gitpod.slack.com/archives/C01KGM9EBD4/p1617220043139300), hoping that a real solution is implemented soon. We're not going to completely remove the alert because it is quite an important one if we can make it work properly.
+
+To silence the alert, follow these steps below
+
+---
+Identify which cluster triggered the alert, this can be done by reading the alert sent to slack.
+
+Like this example, one can see that the alert was triggered at the US cluster at staging.
+![image](https://user-images.githubusercontent.com/24193764/113757147-a7662380-96e8-11eb-979f-9ca52f263417.png)
+
+Go to [https://console.cloud.google.com/](https://console.cloud.google.com/) and find the cluster you want to connect to.
+
+At the top left menu, find `Kubernetes Engine` and click on Clusters:
+![image](https://user-images.githubusercontent.com/24193764/113757218-bc42b700-96e8-11eb-9781-3ad789f44d2e.png)
 
 
-You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
-If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!
+Change the project to the one where your cluster belongs to, like `Staging` for this example, find the correct cluster, click on the three dots on the right and then click on `Connect`:
+![image](https://user-images.githubusercontent.com/24193764/113757316-da101c00-96e8-11eb-9841-2c14119f3075.png)
+
+It will open a modal with a button where you can copy the command to connect to that cluster:
+![image](https://user-images.githubusercontent.com/24193764/113757365-e5fbde00-96e8-11eb-89c9-8555f51c3d69.png)
+
+Open a Gitpod workspace or a terminal at your local environment and run the copied command, you should see a successful message like this one after running it:
+![image](https://user-images.githubusercontent.com/24193764/113757408-f318cd00-96e8-11eb-9a86-81986ae1abad.png)
+
+The next step is to access alertmanager's UI. To do that you can run the command:
+
+`kubectl port-forward -n cluster-monitoring alertmanager-main-0 9093`
+
+If you run the command on a Gitpod workspace, click on Open Browser to access the UI. If you run it locally, then access [http://localhost:9093](http://localhost:9093)
+![image](https://user-images.githubusercontent.com/24193764/113757472-05930680-96e9-11eb-96df-9f8c7ab8903c.png)
+
+Once you've accessed Alertmanager's UI, apply a filter with `alertname="KubeStateMetricsListErrors"` and then click on one of the available Silence buttons:
+![image](https://user-images.githubusercontent.com/24193764/113757520-15124f80-96e9-11eb-8dff-df50cb138087.png)
+
+On the Silence page, there are a few fields that you need to pay attention to:
+
+- Duration - The amount of time the alert will remain silenced, we're suggesting 30d, but feel free to choose your period
+- Matchers - Alerts with matching labels will be silenced, to silence `KubeStateMetricsListErrors` fill the fields as shown in the image below.
+- Creator - Write your own name.
+- Comment - Explain why the alert is being silenced, we suggest the text:
+
+```markdown
+We're deploying an incompatible kube-state-metrics with our k8s cluster. This is a known bug for ksm, please see: https://github.com/kubernetes/kube-state-metrics#compatibility-matrix
+
+We're silencing for a short period hoping that this bug is fixed upstream or that we're able to upgrade our k8s clusters.
+```
+- The last step is to click on `Create`
+
+![image](https://user-images.githubusercontent.com/24193764/113757654-3d9a4980-96e9-11eb-859e-29c93213c1ef.png)
+
+And done, you'll be redirected to a page with your silence in action:
+
+![image](https://user-images.githubusercontent.com/24193764/113757703-4ee35600-96e9-11eb-8d00-3a08e05be459.png)
+
+
+## Solution
+
+We have a couple of options for a real solution here, where none of them is really a trivial one.
+
+### Option 1
+
+Work upstream and make kube-state-metrics compatible with kubernetes clusters on older versions.
+
+### Option 2
+
+Update our clusters to at least 1.19, which is the first version that kube-state-metrics:v2.0.0-rc1 is compatible with.

--- a/runbooks/KubeStateMetricsListErrors.md
+++ b/runbooks/KubeStateMetricsListErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeStateMetricsWatchErrors.md
+++ b/runbooks/KubeStateMetricsWatchErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeStatefulSetGenerationMismatch.md
+++ b/runbooks/KubeStatefulSetGenerationMismatch.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeStatefulSetReplicasMismatch.md
+++ b/runbooks/KubeStatefulSetReplicasMismatch.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeStatefulSetUpdateNotRolledOut.md
+++ b/runbooks/KubeStatefulSetUpdateNotRolledOut.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeVersionMismatch.md
+++ b/runbooks/KubeVersionMismatch.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeletClientCertificateExpiration.md
+++ b/runbooks/KubeletClientCertificateExpiration.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeletClientCertificateRenewalErrors.md
+++ b/runbooks/KubeletClientCertificateRenewalErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeletDown.md
+++ b/runbooks/KubeletDown.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeletPlegDurationHigh.md
+++ b/runbooks/KubeletPlegDurationHigh.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeletPodStartUpLatencyHigh.md
+++ b/runbooks/KubeletPodStartUpLatencyHigh.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeletServerCertificateExpiration.md
+++ b/runbooks/KubeletServerCertificateExpiration.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/KubeletTooManyPods.md
+++ b/runbooks/KubeletTooManyPods.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeClockNotSynchronising.md
+++ b/runbooks/NodeClockNotSynchronising.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeClockSkewDetected.md
+++ b/runbooks/NodeClockSkewDetected.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeFilesystemAlmostOutOfFiles.md
+++ b/runbooks/NodeFilesystemAlmostOutOfFiles.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeFilesystemAlmostOutOfSpace.md
+++ b/runbooks/NodeFilesystemAlmostOutOfSpace.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeFilesystemFilesFillingUp.md
+++ b/runbooks/NodeFilesystemFilesFillingUp.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeFilesystemSpaceFillingUp.md
+++ b/runbooks/NodeFilesystemSpaceFillingUp.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeHighNumberConntrackEntriesUsed.md
+++ b/runbooks/NodeHighNumberConntrackEntriesUsed.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeNetworkInterfaceFlapping.md
+++ b/runbooks/NodeNetworkInterfaceFlapping.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeNetworkReceiveErrs.md
+++ b/runbooks/NodeNetworkReceiveErrs.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeNetworkTransmitErrs.md
+++ b/runbooks/NodeNetworkTransmitErrs.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeRAIDDegraded.md
+++ b/runbooks/NodeRAIDDegraded.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeRAIDDiskFailure.md
+++ b/runbooks/NodeRAIDDiskFailure.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/NodeTextFileCollectorScrapeError.md
+++ b/runbooks/NodeTextFileCollectorScrapeError.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusBadConfig.md
+++ b/runbooks/PrometheusBadConfig.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusDuplicateTimestamps.md
+++ b/runbooks/PrometheusDuplicateTimestamps.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusErrorSendingAlertsToAnyAlertmanager.md
+++ b/runbooks/PrometheusErrorSendingAlertsToAnyAlertmanager.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusErrorSendingAlertsToSomeAlertmanagers.md
+++ b/runbooks/PrometheusErrorSendingAlertsToSomeAlertmanagers.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusMissingRuleEvaluations.md
+++ b/runbooks/PrometheusMissingRuleEvaluations.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusNotConnectedToAlertmanagers.md
+++ b/runbooks/PrometheusNotConnectedToAlertmanagers.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusNotIngestingSamples.md
+++ b/runbooks/PrometheusNotIngestingSamples.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusNotificationQueueRunningFull.md
+++ b/runbooks/PrometheusNotificationQueueRunningFull.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOperatorListErrors.md
+++ b/runbooks/PrometheusOperatorListErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOperatorNodeLookupErrors.md
+++ b/runbooks/PrometheusOperatorNodeLookupErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOperatorNotReady.md
+++ b/runbooks/PrometheusOperatorNotReady.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOperatorReconcileErrors.md
+++ b/runbooks/PrometheusOperatorReconcileErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOperatorRejectedResources.md
+++ b/runbooks/PrometheusOperatorRejectedResources.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOperatorSyncFailed.md
+++ b/runbooks/PrometheusOperatorSyncFailed.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOperatorWatchErrors.md
+++ b/runbooks/PrometheusOperatorWatchErrors.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusOutOfOrderTimestamps.md
+++ b/runbooks/PrometheusOutOfOrderTimestamps.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusRemoteStorageFailures.md
+++ b/runbooks/PrometheusRemoteStorageFailures.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusRemoteWriteBehind.md
+++ b/runbooks/PrometheusRemoteWriteBehind.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusRemoteWriteDesiredShards.md
+++ b/runbooks/PrometheusRemoteWriteDesiredShards.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusRuleFailures.md
+++ b/runbooks/PrometheusRuleFailures.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusTSDBCompactionsFailing.md
+++ b/runbooks/PrometheusTSDBCompactionsFailing.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusTSDBReloadsFailing.md
+++ b/runbooks/PrometheusTSDBReloadsFailing.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!

--- a/runbooks/PrometheusTargetLimitHit.md
+++ b/runbooks/PrometheusTargetLimitHit.md
@@ -1,0 +1,5 @@
+Sorry, this runbook wasn't written yet 🙁. Maybe you could try [kube-prometheus wiki](https://github.com/prometheus-operator/kube-prometheus/wiki)?
+
+
+You could also contribute to this project by writting a runbook, and that would be awesome ❤️!
+If you need guidance, you could follow this awesome [runbook template](https://github.com/SkeltonThatcher/run-book-template), or reach out to us on our [community forum](https://community.gitpod.io/)!


### PR DESCRIPTION
This PR changes all alerts `runbook_url` annotation to runbooks hosted in this repository.

It also adds a markdown file to each alert, which will be populated as the alerts get triggered and we see a need for them.